### PR TITLE
Update File.04.0 - Common malware locations (excluding Windows direct…

### DIFF
--- a/File/File.04.0 - Common malware locations (excluding Windows directories).txt
+++ b/File/File.04.0 - Common malware locations (excluding Windows directories).txt
@@ -28,6 +28,6 @@ f.file_version AS File_Version,
 FROM file f 
 JOIN hash h ON f.path = h.path
 WHERE (f.path LIKE 'C:\%' OR f.path LIKE 'D:\%' OR f.path LIKE 'C:\Users\%\Start Menu\%' OR f.path LIKE 'C:\Users\Public\%' OR f.path LIKE 'C:\Users\%\Downloads\%'
-OR f.path LIKE 'C:\Users\%\Desktop\%' OR f.path LIKE 'C:\Users\%\Music\%' OR f.path LIKE 'C:\ProgramData\%' OR f.path LIKE 'C:\Perflogs\%' OR f.path LIKE 'C:\Intel\%' OR f.path LIKE 'C:\Temp\%') 
+OR f.path LIKE 'C:\Users\%\Desktop\%' OR f.path LIKE 'C:\Users\%\Music\%' OR f.path LIKE 'C:\ProgramData\%' OR f.path LIKE 'C:\Perflogs\%' OR f.path LIKE 'C:\Intel\%' OR f.path LIKE 'C:\Temp\%' OR f.path LIKE 'C:\Users\%\Pictures\%') 
 AND (f.filename LIKE '%.exe' OR f.filename LIKE '%.dll' OR f.filename LIKE '%.bat' OR f.filename LIKE '%.cmd' OR f.filename LIKE '%.vbs' OR f.filename LIKE '%.ps1' 
 OR f.filename LIKE '%.js' OR f.filename LIKE '%.dmp' OR f.filename LIKE '%.txt')


### PR DESCRIPTION
…ories).txt

Added OR f.path LIKE 'C:\Users\%\Pictures\%' to query. Change proposed due to missing file path abused by CryLock TA.